### PR TITLE
Fix Hugo theme configuration

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 title = "Independent Impact"
 
 # Theme Config
-theme = "../.."
+theme = "hugo-saasify-theme"
 
 # Enable syntax highlighting
 pygmentsCodeFences = true


### PR DESCRIPTION
## Summary
- point Hugo to the bundled hugo-saasify-theme directory so that shortcode templates are available during local development

## Testing
- npm run build *(fails: `hugo` executable not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d100089d608323a3e257f6157cf905