### PR TITLE
Add shortcode templates required for homepage components

### DIFF
--- a/layouts/shortcodes/client-logos.html
+++ b/layouts/shortcodes/client-logos.html
@@ -1,0 +1,15 @@
+{{ $logos := .Page.Params.client_logos }}
+{{ $animate := eq (lower (.Get "animate" | default "")) "true" }}
+{{ if $logos }}
+<section class="py-12">
+  <div class="container">
+    <div class="grid items-center gap-8 md:grid-cols-3 lg:grid-cols-5">
+      {{ range $logos }}
+      <div class="flex items-center justify-center">
+        <img class="h-12 w-auto max-w-[160px] {{ if $animate }}transition transform hover:scale-105 duration-200{{ end }}" src="{{ .logo }}" alt="{{ .name | default "" | plainify }} logo" loading="lazy" />
+      </div>
+      {{ end }}
+    </div>
+  </div>
+</section>
+{{ end }}

--- a/layouts/shortcodes/cta.html
+++ b/layouts/shortcodes/cta.html
@@ -1,0 +1,23 @@
+{{ $cta := site.Params.cta }}
+{{ if and $cta ($cta.enable | default true) }}
+<section class="cta-section">
+  <div class="container">
+    <div class="cta-gradient rounded-3xl px-8 py-12 text-center text-white" style="--gradient-from: {{ $cta.gradient_from | default "#2563eb" }}; --gradient-to: {{ $cta.gradient_to | default "#7c3aed" }}; --gradient-angle: {{ $cta.gradient_angle | default 45 }};">
+      {{ with $cta.title }}
+      <h2 class="text-3xl font-heading font-bold">{{ . }}</h2>
+      {{ end }}
+      {{ with $cta.description }}
+      <p class="mt-4 text-lg text-white/90">{{ . }}</p>
+      {{ end }}
+      <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        {{ with $cta.primary_button }}
+        <a class="btn-primary" href="{{ .url | default "#" }}">{{ .text }}</a>
+        {{ end }}
+        {{ with $cta.secondary_button }}
+        <a class="btn-outline border-white text-white hover:bg-white/10" href="{{ .url | default "#" }}">{{ .text }}</a>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}

--- a/layouts/shortcodes/feature.html
+++ b/layouts/shortcodes/feature.html
@@ -1,0 +1,52 @@
+{{ $title := .Get "title" }}
+{{ $description := .Get "description" }}
+{{ $badge := .Get "badge" }}
+{{ $badgeColor := .Get "badgeColor" | default "#2563eb" }}
+{{ $image := .Get "image" }}
+{{ $buttonText := .Get "buttonText" }}
+{{ $buttonLink := .Get "buttonLink" | default "#" }}
+{{ $features := split (.Get "features" | default "") "," }}
+{{ $imagePosition := lower (.Get "imagePosition" | default "right") }}
+{{ $reverse := eq $imagePosition "left" }}
+{{ $scratch := newScratch }}
+{{ $scratch.Set "items" (slice) }}
+{{ range $features }}
+  {{ $item := trim . " \t\n\r" }}
+  {{ if $item }}
+    {{ $scratch.Add "items" (slice $item) }}
+  {{ end }}
+{{ end }}
+{{ $items := $scratch.Get "items" }}
+<div class="card h-full">
+  <div class="flex flex-col gap-6 {{ if $reverse }}lg:flex-row-reverse{{ else }}lg:flex-row{{ end }}">
+    <div class="flex-1 space-y-4">
+      {{ with $badge }}
+      <span class="inline-flex items-center rounded-full px-4 py-1 text-sm font-semibold text-white" style="background-color: {{ $badgeColor }}">{{ . }}</span>
+      {{ end }}
+      {{ with $title }}
+      <h3 class="text-2xl font-heading font-bold text-gray-900">{{ . }}</h3>
+      {{ end }}
+      {{ with $description }}
+      <p class="text-gray-600">{{ . }}</p>
+      {{ end }}
+      {{ if gt (len $items) 0 }}
+      <ul class="space-y-2">
+        {{ range $items }}
+        <li class="flex items-start gap-3">
+          <span class="mt-1 h-2 w-2 rounded-full bg-primary-500"></span>
+          <span>{{ . }}</span>
+        </li>
+        {{ end }}
+      </ul>
+      {{ end }}
+      {{ with $buttonText }}
+      <a class="btn-secondary inline-flex" href="{{ $buttonLink }}">{{ . }}</a>
+      {{ end }}
+    </div>
+    {{ with $image }}
+    <div class="flex-1">
+      <img class="w-full h-full object-contain" src="{{ . }}" alt="{{ $title | default "" | plainify }} illustration" loading="lazy" />
+    </div>
+    {{ end }}
+  </div>
+</div>

--- a/layouts/shortcodes/features-section.html
+++ b/layouts/shortcodes/features-section.html
@@ -1,0 +1,17 @@
+{{ $title := .Get "title" }}
+{{ $description := .Get "description" }}
+<section class="section bg-white">
+  <div class="container space-y-12">
+    <div class="mx-auto max-w-3xl text-center space-y-4">
+      {{ with $title }}
+      <h2 class="text-3xl font-heading font-bold text-gray-900">{{ . }}</h2>
+      {{ end }}
+      {{ with $description }}
+      <p class="text-lg text-gray-600">{{ . }}</p>
+      {{ end }}
+    </div>
+    <div class="grid gap-8 lg:grid-cols-3">
+      {{ .Inner | safeHTML }}
+    </div>
+  </div>
+</section>

--- a/layouts/shortcodes/hero.html
+++ b/layouts/shortcodes/hero.html
@@ -1,0 +1,36 @@
+{{ $headline := .Get "headline" | default (.Page.Title) }}
+{{ $headlineText := $headline | default "" | plainify }}
+{{ $sub := .Get "sub_headline" }}
+{{ $primaryText := .Get "primary_button_text" }}
+{{ $primaryURL := .Get "primary_button_url" | default "#" }}
+{{ $secondaryText := .Get "secondary_button_text" }}
+{{ $secondaryURL := .Get "secondary_button_url" | default "#" }}
+{{ $image := .Get "hero_image" }}
+{{ $gradientFrom := .Get "gradient-from" | default "#eff6ff" }}
+{{ $gradientTo := .Get "gradient-to" | default "#ede9fe" }}
+{{ $gradientAngle := .Get "gradient-angle" | default "135" }}
+<section class="relative overflow-hidden py-20" style="background: linear-gradient({{ $gradientAngle }}deg, {{ $gradientFrom }}, {{ $gradientTo }});">
+  <div class="container grid gap-16 items-center lg:grid-cols-2">
+    <div class="space-y-6 text-center lg:text-left">
+      {{ with $headline }}
+      <h1 class="text-4xl sm:text-5xl font-heading font-bold text-gray-900">{{ . }}</h1>
+      {{ end }}
+      {{ with $sub }}
+      <p class="text-lg text-gray-700 max-w-2xl mx-auto lg:mx-0">{{ . }}</p>
+      {{ end }}
+      <div class="flex flex-col sm:flex-row items-center justify-center lg:justify-start gap-4">
+        {{ with $primaryText }}
+        <a class="btn-primary" href="{{ $primaryURL }}">{{ . }}</a>
+        {{ end }}
+        {{ with $secondaryText }}
+        <a class="btn-outline" href="{{ $secondaryURL }}">{{ . }}</a>
+        {{ end }}
+      </div>
+    </div>
+    {{ with $image }}
+    <div class="relative">
+      <img class="w-full max-w-xl mx-auto" src="{{ . }}" alt="{{ $headlineText }} illustration" loading="lazy" />
+    </div>
+    {{ end }}
+  </div>
+</section>

--- a/layouts/shortcodes/testimonials.html
+++ b/layouts/shortcodes/testimonials.html
@@ -1,0 +1,37 @@
+{{ $title := .Get "title" }}
+{{ $description := .Get "description" }}
+{{ $animate := eq (lower (.Get "animate" | default "")) "true" }}
+{{ $background := .Get "background-color" }}
+{{ $testimonials := .Page.Params.testimonials }}
+{{ if $testimonials }}
+<section class="section" {{ with $background }}style="background-color: {{ . }}"{{ end }}>
+  <div class="container space-y-12">
+    <div class="mx-auto max-w-3xl text-center space-y-4">
+      {{ with $title }}
+      <h2 class="text-3xl font-heading font-bold text-gray-900">{{ . }}</h2>
+      {{ end }}
+      {{ with $description }}
+      <p class="text-lg text-gray-600">{{ . }}</p>
+      {{ end }}
+    </div>
+    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+      {{ range $testimonial := $testimonials }}
+      <article class="card h-full {{ if $animate }}transition duration-200 hover:-translate-y-1 hover:shadow-lg{{ end }}">
+        <div class="flex flex-col gap-4">
+          <div class="flex items-center gap-4">
+            {{ with $testimonial.avatar }}
+            <img class="h-12 w-12 rounded-full" src="{{ . }}" alt="{{ $testimonial.name | default "" | plainify }} avatar" loading="lazy" />
+            {{ end }}
+            <div>
+              <p class="font-semibold text-gray-900">{{ $testimonial.name }}</p>
+              <p class="text-sm text-gray-500">{{ $testimonial.title }}</p>
+            </div>
+          </div>
+          <p class="text-gray-600">“{{ $testimonial.quote }}”</p>
+        </div>
+      </article>
+      {{ end }}
+    </div>
+  </div>
+</section>
+{{ end }}


### PR DESCRIPTION
## Summary
- add shortcode implementations for the homepage hero, features, testimonials, logos, and CTA sections
- wire the shortcodes to front matter and site parameters with Tailwind-friendly markup

## Testing
- not run (Hugo CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_b_68d10489ac04832395d4f959fb6e72cf