### PR TITLE
Update philosophy details and add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Independent Impact Website
+
+This repository contains the Hugo project for the Independent Impact website. It uses Tailwind CSS to generate the final stylesheets before running the Hugo build.
+
+## Prerequisites
+
+Ensure the following tools are installed locally:
+
+- [Node.js](https://nodejs.org/) (version 18 or later recommended)
+- [npm](https://www.npmjs.com/) (bundled with Node.js)
+- [Hugo Extended](https://gohugo.io/getting-started/installing/) (v0.111 or later)
+
+## Install dependencies
+
+```bash
+npm install
+```
+
+## Local development
+
+Run the Tailwind compiler and Hugo development server together:
+
+```bash
+npm start
+```
+
+The site will be served with live reload at the address shown in the terminal (typically `http://localhost:1313`).
+
+## Production build
+
+Generate the optimised CSS bundle and static site output:
+
+```bash
+npm run build
+```
+
+The compiled site is written to the `public/` directory.
+
+## Additional resources
+
+- `content/` – Markdown content for each page.
+- `assets/css/main.css` – Tailwind entrypoint that is compiled into `static/css/style.css`.
+- `themes/` – Hugo theme files.

--- a/content/_index.md
+++ b/content/_index.md
@@ -104,12 +104,12 @@ description: "Independent Impact makes transparent, verifiable human impact acco
 
 Independent Impact grows from a decade of experimentation in verifiable impact accounting. Highlights include:
 
-- **Aartum Whitepaper** – articulated the vision that unique cryptographic representations of verified communal benefits could function as symbols of value, while calling out veracity as the central challenge for blockchain-based impact ecosystems.
-- **AIAO Ontology** – collaborative work in the Hyperledger Climate Action and Accounting SIG to define a foundational ontology for anthropogenic impact accounting, enabling comparison across methodologies and metrics. _What is the full list of published ontologies and their current stewardship?_ 
-- **Guardian cookstove methodology** – demonstrates how rigorous methodologies can be executed within open verification workflows. _Do we have public resources or links describing this methodology?_
+- **Aartum Whitepaper** – articulated the vision that unique cryptographic representations of verified communal benefits could function as symbols of value, while calling out veracity as the central challenge for blockchain-based impact ecosystems. Read the original paper at [aartum.io/pdf/aartum_programme_whitepaper_ver5](https://aartum.io/pdf/aartum_programme_whitepaper_ver5).
+- **AIAO Ontology** – collaborative work in the Hyperledger Climate Action and Accounting SIG to define a foundational ontology for anthropogenic impact accounting, enabling comparison across methodologies and metrics. The Standards Working Group of the Linux Foundation Decentralized Trust continues to steward AIAO alongside the [Impact Ontology](https://w3id.org/impactont), [Claim Ontology](https://w3id.org/claimont), and [Information Communication Ontology](https://w3id.org/infocomm).
+- **Guardian cookstove methodology** – demonstrates how rigorous methodologies can be executed within open verification workflows. Explore the methodology in practice through our [cookstove case study video](https://www.youtube.com/watch?v=BQRoSuIp5UE&t=81s).
 - **Launch of Independent Impact** – initiated the platform that operationalises reputation, transparency, and verifiable compute for real-world impact accounting.
-- **Adaptation methodology** – extends the platform beyond mitigation use cases. _What outcomes and metrics does the adaptation methodology currently prioritise?_
-- **Publication of AIAO** – formal release of the ontology to the wider community, establishing shared language for anthropogenic impact.
+- **Adaptation methodology** – extends the platform beyond mitigation use cases. A worked example with real project data is available in the [Adaptation Methodology reference](/References/Methodology.pdf).
+- **Publication of AIAO** – formal release of the ontology to the wider community in September 2025, establishing shared language for anthropogenic impact.
 
 ## Active Capabilities
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "hugo-sassify-theme",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^7.1.0"
+      },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.10",
@@ -158,6 +161,20 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ansi-regex": {
@@ -555,7 +572,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -1407,10 +1423,10 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
-      "dev": true,
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -1927,8 +1943,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "postcss": "^8.4.31",
     "postcss-cli": "^10.1.0",
     "tailwindcss": "^3.3.5"
+  },
+  "dependencies": {
+    "postcss-selector-parser": "^7.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace placeholder prompts in the home page history section with linked resources covering the Aartum whitepaper, Independent Impact ontologies, cookstove work, adaptation methodology, and AIAO publication date
- add a repository README that documents prerequisites plus commands for installing dependencies, running a local server, and producing a production build
- declare postcss-selector-parser as an explicit dependency so fresh installs have all modules required for Tailwind and Hugo builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d11f88f1448323b8c7f41c76861fcd