### PR TITLE
Align site color system with Independent Impact spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ The compiled site is written to the `public/` directory.
 - `content/` – Markdown content for each page.
 - `assets/css/main.css` – Tailwind entrypoint that is compiled into `static/css/style.css`.
 - `themes/` – Hugo theme files.
+
+## Color system
+
+The site palette is defined through CSS variables and Tailwind aliases in `assets/css/main.css` and `tailwind.config.js`, following the [Independent Impact colour specification](References/independent-impact-color-spec.md). Update those token files when adjusting colours so that components continue to consume the shared design system.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2,17 +2,72 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --brand-blue-500: #1E88E5;
+  --brand-blue-700: #1976D2;
+  --brand-blue-800: #1565C0;
+  --trust-navy: #0A2240;
+  --verify-green-700: #15803D;
+  --accent-cyan: #06B6D4;
+  --amber-500: #F59E0B;
+  --amber-700: #B45309;
+  --error-600: #DC2626;
+
+  --bg: #FFFFFF;
+  --surface: #F8FAFC;
+  --border: #E2E8F0;
+  --text: #0F172A;
+  --text-2: #334155;
+}
+
+.dark {
+  --bg: #0B1220;
+  --surface: #111827;
+  --border: #1F2937;
+  --text: #F1F5F9;
+  --text-2: #CBD5E1;
+}
+
 @layer base {
   html {
     @apply scroll-smooth;
-  }
-  
-  body {
-    @apply font-sans text-gray-700 antialiased;
+    color-scheme: light dark;
   }
 
-  h1, h2, h3, h4, h5, h6 {
-    @apply font-heading font-bold text-gray-900;
+  body {
+    @apply font-sans antialiased;
+    background-color: var(--bg);
+    color: var(--text);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-heading font-bold;
+    color: var(--brand-blue-800);
+  }
+
+  a {
+    color: var(--brand-blue-800);
+    text-decoration: none;
+  }
+
+  a:hover,
+  a:focus-visible {
+    color: var(--brand-blue-500);
+    text-decoration: underline;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--trust-navy);
+    outline-offset: 2px;
+  }
+
+  .dark :focus-visible {
+    outline: 2px solid var(--text);
   }
 }
 
@@ -31,7 +86,11 @@
   }
 
   .cta-gradient {
-    background: linear-gradient(calc(var(--gradient-angle) * 1deg), var(--gradient-from), var(--gradient-to));
+    background: linear-gradient(
+      calc(var(--gradient-angle) * 1deg),
+      var(--gradient-from),
+      var(--gradient-to)
+    );
   }
 
   .btn {
@@ -40,15 +99,31 @@
   }
 
   .btn-primary {
-    @apply btn bg-primary-600 text-white hover:bg-primary-700 hover:scale-105;
+    @apply btn text-white hover:scale-105;
+    background-color: var(--brand-blue-700);
+  }
+
+  .btn-primary:hover,
+  .btn-primary:focus-visible {
+    background-color: var(--brand-blue-800);
   }
 
   .btn-secondary {
-    @apply btn bg-secondary-600 text-white hover:bg-secondary-700 hover:scale-105;
+    @apply btn hover:scale-105;
+    background-color: transparent;
+    border: 2px solid var(--brand-blue-500);
+    color: var(--brand-blue-800);
+  }
+
+  .btn-secondary:hover,
+  .btn-secondary:focus-visible {
+    background-color: rgba(30, 136, 229, 0.08);
   }
 
   .btn-outline {
-    @apply btn border-2 border-primary-600 text-primary-600 hover:scale-105;
+    @apply btn hover:scale-105;
+    border: 2px solid var(--brand-blue-700);
+    color: var(--brand-blue-700);
   }
 
   .container {
@@ -60,12 +135,20 @@
   }
 
   .card {
-    @apply bg-white p-6 transition duration-200 hover:shadow-md;
+    @apply p-6 transition duration-200 hover:shadow-md;
     border-radius: 2rem;
+    background-color: var(--surface);
+    border: 1px solid var(--border);
   }
 
   .nav-link {
-    @apply text-gray-600 hover:text-primary-600 font-bold transition duration-200;
+    @apply font-bold transition duration-200;
+    color: var(--text-2);
+  }
+
+  .nav-link:hover,
+  .nav-link:focus-visible {
+    color: var(--brand-blue-500);
   }
 
   .feature-grid {
@@ -74,7 +157,8 @@
 
   /* Blog and Syntax Highlighting Styles */
   .highlight {
-    @apply text-sm font-mono text-gray-200;
+    @apply text-sm font-mono;
+    color: var(--text);
   }
 
   .highlight table {
@@ -86,47 +170,60 @@
   }
 
   .highlight table td:first-child {
-    @apply pr-4 text-right select-none text-gray-500 border-r border-gray-700;
+    @apply pr-4 text-right select-none text-body-2 border-r border-border;
   }
 
   .highlight table td:last-child {
     @apply pl-4 w-full;
   }
 
-  .highlight .k, .highlight .kd {
-    @apply text-purple-400 font-semibold;
+  .highlight .k,
+  .highlight .kd {
+    color: var(--brand-blue-500);
+    font-weight: 600;
   }
 
-  .highlight .nf, .highlight .nx {
-    @apply text-blue-400;
+  .highlight .nf,
+  .highlight .nx {
+    color: var(--brand-blue-800);
   }
 
-  .highlight .s, .highlight .s1, .highlight .s2 {
-    @apply text-green-400;
+  .highlight .s,
+  .highlight .s1,
+  .highlight .s2 {
+    color: var(--verify-green-700);
   }
 
-  .highlight .mi, .highlight .mf {
-    @apply text-orange-400;
+  .highlight .mi,
+  .highlight .mf {
+    color: var(--amber-500);
   }
 
-  .highlight .c, .highlight .c1, .highlight .cm {
-    @apply text-gray-500 italic;
+  .highlight .c,
+  .highlight .c1,
+  .highlight .cm {
+    color: var(--text-2);
+    font-style: italic;
   }
 
   .highlight .o {
-    @apply text-yellow-400;
+    color: var(--accent-cyan);
   }
 
   .highlight .p {
-    @apply text-gray-400;
+    color: var(--text-2);
   }
 
   .prose {
     @apply max-w-none;
   }
 
-  .prose h1, .prose h2, .prose h3, .prose h4 {
-    @apply font-heading font-bold text-gray-900;
+  .prose h1,
+  .prose h2,
+  .prose h3,
+  .prose h4 {
+    @apply font-heading font-bold;
+    color: var(--brand-blue-800);
   }
 
   .prose h1 {
@@ -142,14 +239,23 @@
   }
 
   .prose p {
-    @apply text-gray-700 leading-relaxed mb-6;
+    @apply leading-relaxed mb-6;
+    color: var(--text);
   }
 
   .prose a {
-    @apply text-primary-600 hover:text-primary-700 no-underline;
+    color: var(--brand-blue-800);
+    text-decoration: none;
   }
 
-  .prose ul, .prose ol {
+  .prose a:hover,
+  .prose a:focus-visible {
+    color: var(--brand-blue-500);
+    text-decoration: underline;
+  }
+
+  .prose ul,
+  .prose ol {
     @apply my-6 ml-6;
   }
 
@@ -158,7 +264,8 @@
   }
 
   .prose blockquote {
-    @apply border-l-4 border-gray-200 pl-4 italic text-gray-700 my-8;
+    @apply border-l-4 border-border pl-4 italic my-8;
+    color: var(--text);
   }
 
   .prose img {
@@ -166,11 +273,16 @@
   }
 
   .prose code:not(pre code) {
-    @apply bg-gray-100 text-gray-900 px-1.5 py-0.5 rounded text-sm font-mono;
+    @apply px-1.5 py-0.5 rounded text-sm font-mono;
+    background-color: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--brand-blue-800);
   }
 
   .table-of-contents {
-    @apply bg-gray-50 p-6 rounded-lg my-8;
+    @apply p-6 rounded-lg my-8;
+    background-color: var(--surface);
+    border: 1px solid var(--border);
   }
 
   .table-of-contents nav {
@@ -178,7 +290,7 @@
   }
 
   .table-of-contents a {
-    @apply text-gray-700 hover:text-primary-600 no-underline;
+    color: var(--brand-blue-800);
   }
 
   .table-of-contents ul {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,18 +7,18 @@
   {{ with .Params.description }}<meta name="description" content="{{ . }}" />{{ else }}{{ with .Site.Params.description }}<meta name="description" content="{{ . }}" />{{ end }}{{ end }}
   <link rel="stylesheet" href="{{ "css/style.css" | relURL }}" />
 </head>
-<body class="bg-gray-50 text-gray-700">
-  <header class="bg-white border-b border-gray-200">
+<body class="bg-background text-body">
+  <header class="bg-surface border-b border-border">
     <div class="container flex flex-col gap-4 py-6 md:flex-row md:items-center md:justify-between">
-      <a href="{{ "/" | relURL }}" class="flex items-center gap-3 text-xl font-heading font-bold text-gray-900">
+      <a href="{{ "/" | relURL }}" class="flex items-center gap-3 text-xl font-heading font-bold text-brand-blue-800">
         {{ with .Site.Params.logo }}<img src="{{ . }}" alt="{{ $.Site.Title }} logo" class="h-10 w-10" loading="lazy" />{{ end }}
         <span>{{ .Site.Title }}</span>
       </a>
       {{ if .Site.Menus.main }}
       <nav>
-        <ul class="flex flex-wrap gap-6 text-sm font-medium text-gray-600">
+        <ul class="flex flex-wrap gap-6 text-sm font-medium text-body-2">
           {{ range .Site.Menus.main }}
-            <li><a class="hover:text-primary-600" href="{{ .URL }}">{{ .Name }}</a></li>
+            <li><a class="nav-link" href="{{ .URL }}">{{ .Name }}</a></li>
           {{ end }}
         </ul>
       </nav>
@@ -28,28 +28,28 @@
   <main>
     {{ block "main" . }}{{ end }}
   </main>
-  <footer class="bg-white border-t border-gray-200 mt-16">
+  <footer class="bg-surface border-t border-border mt-16">
     <div class="container grid gap-10 py-12 md:grid-cols-3">
       <div>
-        <h2 class="text-lg font-heading font-semibold text-gray-900">{{ .Site.Title }}</h2>
+        <h2 class="text-lg font-heading font-semibold text-brand-blue-800">{{ .Site.Title }}</h2>
         {{ with .Site.Params.description }}
-        <p class="mt-4 text-sm text-gray-600">{{ . }}</p>
+        <p class="mt-4 text-sm text-body-2">{{ . }}</p>
         {{ end }}
       </div>
       {{ range $i, $menu := (slice .Site.Menus.footer_column_1 .Site.Menus.footer_column_2 .Site.Menus.footer_column_3) }}
         {{ if $menu }}
         <div>
-          <h3 class="text-sm font-heading font-semibold uppercase tracking-wide text-gray-500">{{ index (slice "Features" "Organisation" "Policies") $i }}</h3>
-          <ul class="mt-4 space-y-3 text-sm text-gray-600">
+          <h3 class="text-sm font-heading font-semibold uppercase tracking-wide text-body-2">{{ index (slice "Features" "Organisation" "Policies") $i }}</h3>
+          <ul class="mt-4 space-y-3 text-sm text-body-2">
             {{ range $menu }}
-              <li><a class="hover:text-primary-600" href="{{ .URL }}">{{ .Name }}</a></li>
+              <li><a class="nav-link" href="{{ .URL }}">{{ .Name }}</a></li>
             {{ end }}
           </ul>
         </div>
         {{ end }}
       {{ end }}
     </div>
-    <div class="border-t border-gray-200 py-6 text-center text-xs text-gray-500">
+    <div class="border-t border-border py-6 text-center text-xs text-body-2">
       © {{ now.Format "2006" }} {{ .Site.Title }}. All rights reserved.
     </div>
   </footer>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,9 +1,9 @@
 {{ define "main" }}
   <section class="container py-12">
     <header class="max-w-3xl">
-      <h1 class="text-4xl font-heading font-bold text-gray-900">{{ .Title }}</h1>
+      <h1 class="text-4xl font-heading font-bold text-brand-blue-800">{{ .Title }}</h1>
       {{ with .Description }}
-      <p class="mt-3 text-lg text-gray-600">{{ . }}</p>
+      <p class="mt-3 text-lg text-body-2">{{ . }}</p>
       {{ end }}
     </header>
     {{ if .Content }}
@@ -11,15 +11,15 @@
     {{ end }}
     <div class="mt-12 space-y-10">
       {{ range .Pages }}
-        <article class="rounded-3xl bg-white p-8 shadow-sm">
-          <h2 class="text-2xl font-heading font-semibold text-gray-900"><a class="hover:text-primary-600" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+        <article class="rounded-3xl bg-surface p-8 shadow-sm border border-border">
+          <h2 class="text-2xl font-heading font-semibold text-brand-blue-800"><a class="nav-link" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
           {{ with .Summary }}
-          <p class="mt-3 text-gray-600">{{ . }}</p>
+          <p class="mt-3 text-body-2">{{ . }}</p>
           {{ end }}
-          <a class="mt-4 inline-flex items-center text-sm font-semibold text-primary-600" href="{{ .RelPermalink }}">Read more →</a>
+          <a class="mt-4 inline-flex items-center text-sm font-semibold text-brand-blue-700" href="{{ .RelPermalink }}">Read more →</a>
         </article>
       {{ else }}
-        <p class="mt-10 text-gray-600">No entries available yet.</p>
+        <p class="mt-10 text-body-2">No entries available yet.</p>
       {{ end }}
     </div>
   </section>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,9 @@
 {{ define "main" }}
   <article class="container prose py-12">
     <header class="mb-8">
-      <h1 class="text-4xl font-heading font-bold text-gray-900">{{ .Title }}</h1>
+      <h1 class="text-4xl font-heading font-bold text-brand-blue-800">{{ .Title }}</h1>
       {{ with .Description }}
-      <p class="mt-2 text-lg text-gray-600">{{ . }}</p>
+      <p class="mt-2 text-lg text-body-2">{{ . }}</p>
       {{ end }}
     </header>
     {{ .Content }}

--- a/layouts/shortcodes/cta.html
+++ b/layouts/shortcodes/cta.html
@@ -2,7 +2,7 @@
 {{ if and $cta ($cta.enable | default true) }}
 <section class="cta-section">
   <div class="container">
-    <div class="cta-gradient rounded-3xl px-8 py-12 text-center text-white" style="--gradient-from: {{ $cta.gradient_from | default "#2563eb" }}; --gradient-to: {{ $cta.gradient_to | default "#7c3aed" }}; --gradient-angle: {{ $cta.gradient_angle | default 45 }};">
+    <div class="cta-gradient rounded-3xl px-8 py-12 text-center text-white" style="--gradient-from: {{ $cta.gradient_from | default "var(--brand-blue-500)" }}; --gradient-to: {{ $cta.gradient_to | default "var(--accent-cyan)" }}; --gradient-angle: {{ $cta.gradient_angle | default 135 }};">
       {{ with $cta.title }}
       <h2 class="text-3xl font-heading font-bold">{{ . }}</h2>
       {{ end }}

--- a/layouts/shortcodes/feature.html
+++ b/layouts/shortcodes/feature.html
@@ -1,7 +1,7 @@
 {{ $title := .Get "title" }}
 {{ $description := .Get "description" }}
 {{ $badge := .Get "badge" }}
-{{ $badgeColor := .Get "badgeColor" | default "#2563eb" }}
+{{ $badgeColor := .Get "badgeColor" | default "var(--verify-green-700)" }}
 {{ $image := .Get "image" }}
 {{ $buttonText := .Get "buttonText" }}
 {{ $buttonLink := .Get "buttonLink" | default "#" }}
@@ -24,16 +24,16 @@
       <span class="inline-flex items-center rounded-full px-4 py-1 text-sm font-semibold text-white" style="background-color: {{ $badgeColor }}">{{ . }}</span>
       {{ end }}
       {{ with $title }}
-      <h3 class="text-2xl font-heading font-bold text-gray-900">{{ . }}</h3>
+      <h3 class="text-2xl font-heading font-bold text-brand-blue-800">{{ . }}</h3>
       {{ end }}
       {{ with $description }}
-      <p class="text-gray-600">{{ . }}</p>
+      <p class="text-body-2">{{ . }}</p>
       {{ end }}
       {{ if gt (len $items) 0 }}
       <ul class="space-y-2">
         {{ range $items }}
         <li class="flex items-start gap-3">
-          <span class="mt-1 h-2 w-2 rounded-full bg-primary-500"></span>
+          <span class="mt-1 h-2 w-2 rounded-full bg-brand-blue-500"></span>
           <span>{{ . }}</span>
         </li>
         {{ end }}

--- a/layouts/shortcodes/features-section.html
+++ b/layouts/shortcodes/features-section.html
@@ -1,13 +1,13 @@
 {{ $title := .Get "title" }}
 {{ $description := .Get "description" }}
-<section class="section bg-white">
+<section class="section bg-background">
   <div class="container space-y-12">
     <div class="mx-auto max-w-3xl text-center space-y-4">
       {{ with $title }}
-      <h2 class="text-3xl font-heading font-bold text-gray-900">{{ . }}</h2>
+      <h2 class="text-3xl font-heading font-bold text-brand-blue-800">{{ . }}</h2>
       {{ end }}
       {{ with $description }}
-      <p class="text-lg text-gray-600">{{ . }}</p>
+      <p class="text-lg text-body-2">{{ . }}</p>
       {{ end }}
     </div>
     <div class="grid gap-8 lg:grid-cols-3">

--- a/layouts/shortcodes/hero.html
+++ b/layouts/shortcodes/hero.html
@@ -6,17 +6,17 @@
 {{ $secondaryText := .Get "secondary_button_text" }}
 {{ $secondaryURL := .Get "secondary_button_url" | default "#" }}
 {{ $image := .Get "hero_image" }}
-{{ $gradientFrom := .Get "gradient-from" | default "#eff6ff" }}
-{{ $gradientTo := .Get "gradient-to" | default "#ede9fe" }}
+{{ $gradientFrom := .Get "gradient-from" | default "var(--brand-blue-500)" }}
+{{ $gradientTo := .Get "gradient-to" | default "var(--accent-cyan)" }}
 {{ $gradientAngle := .Get "gradient-angle" | default "135" }}
 <section class="relative overflow-hidden py-20" style="background: linear-gradient({{ $gradientAngle }}deg, {{ $gradientFrom }}, {{ $gradientTo }});">
   <div class="container grid gap-16 items-center lg:grid-cols-2">
     <div class="space-y-6 text-center lg:text-left">
       {{ with $headline }}
-      <h1 class="text-4xl sm:text-5xl font-heading font-bold text-gray-900">{{ . }}</h1>
+      <h1 class="text-4xl sm:text-5xl font-heading font-bold text-brand-blue-800">{{ . }}</h1>
       {{ end }}
       {{ with $sub }}
-      <p class="text-lg text-gray-700 max-w-2xl mx-auto lg:mx-0">{{ . }}</p>
+      <p class="text-lg text-body max-w-2xl mx-auto lg:mx-0">{{ . }}</p>
       {{ end }}
       <div class="flex flex-col sm:flex-row items-center justify-center lg:justify-start gap-4">
         {{ with $primaryText }}

--- a/layouts/shortcodes/testimonials.html
+++ b/layouts/shortcodes/testimonials.html
@@ -8,10 +8,10 @@
   <div class="container space-y-12">
     <div class="mx-auto max-w-3xl text-center space-y-4">
       {{ with $title }}
-      <h2 class="text-3xl font-heading font-bold text-gray-900">{{ . }}</h2>
+      <h2 class="text-3xl font-heading font-bold text-brand-blue-800">{{ . }}</h2>
       {{ end }}
       {{ with $description }}
-      <p class="text-lg text-gray-600">{{ . }}</p>
+      <p class="text-lg text-body-2">{{ . }}</p>
       {{ end }}
     </div>
     <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
@@ -23,11 +23,11 @@
             <img class="h-12 w-12 rounded-full" src="{{ . }}" alt="{{ $testimonial.name | default "" | plainify }} avatar" loading="lazy" />
             {{ end }}
             <div>
-              <p class="font-semibold text-gray-900">{{ $testimonial.name }}</p>
-              <p class="text-sm text-gray-500">{{ $testimonial.title }}</p>
+              <p class="font-semibold text-brand-blue-800">{{ $testimonial.name }}</p>
+              <p class="text-sm text-body-2">{{ $testimonial.title }}</p>
             </div>
           </div>
-          <p class="text-gray-600">“{{ $testimonial.quote }}”</p>
+          <p class="text-body-2">“{{ $testimonial.quote }}”</p>
         </div>
       </article>
       {{ end }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,28 +13,43 @@ module.exports = {
       },
       colors: {
         primary: {
-          50: '#eff6ff',
-          100: '#dbeafe',
-          200: '#bfdbfe',
-          300: '#93c5fd',
-          400: '#60a5fa',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          800: '#1e40af',
-          900: '#1e3a8a',
+          500: 'var(--brand-blue-500)',
+          600: 'var(--brand-blue-700)',
+          700: 'var(--brand-blue-800)',
         },
-        secondary: {
-          50: '#f5f3ff',
-          100: '#ede9fe',
-          200: '#ddd6fe',
-          300: '#c4b5fd',
-          400: '#a78bfa',
-          500: '#8b5cf6',
-          600: '#7c3aed',
-          700: '#6d28d9',
-          800: '#5b21b6',
-          900: '#4c1d95',
+        brand: {
+          blue: {
+            500: 'var(--brand-blue-500)',
+            700: 'var(--brand-blue-700)',
+            800: 'var(--brand-blue-800)',
+          },
+          navy: 'var(--trust-navy)',
+        },
+        verify: {
+          green: {
+            700: 'var(--verify-green-700)',
+          },
+        },
+        accent: {
+          cyan: 'var(--accent-cyan)',
+        },
+        warn: {
+          amber: {
+            500: 'var(--amber-500)',
+            700: 'var(--amber-700)',
+          },
+        },
+        error: {
+          red: {
+            600: 'var(--error-600)',
+          },
+        },
+        background: 'var(--bg)',
+        surface: 'var(--surface)',
+        border: 'var(--border)',
+        body: {
+          DEFAULT: 'var(--text)',
+          2: 'var(--text-2)',
         },
       },
     },


### PR DESCRIPTION
## Summary
- define shared colour tokens, focus styles, and component theming that align with the Independent Impact palette
- map Tailwind colour utilities to the new design tokens and refresh global navigation, card, and prose treatments
- update shortcodes and layouts to consume the new variables and link the README to the colour specification

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1364b8ff88323a691daa10c71b4c8